### PR TITLE
Improve README

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 # ensure unix line endings on windows for files that need them.
 *.sh eol=lf
 codelists/* eol=lf
+
+# Show R Markdown in repo homepage Languages pane
+*.[Rr]md linguist-detectable

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,10 @@ source_lines("analysis/cox-ipw.R", 1:83)
 optparse::print_help(opt_parser)
 ```
 
-This action can be specified in the `project.yaml` with its default values as follows.
+This action can be specified in the `project.yaml` with its options at their default values as follows, 
+where you should replace `[version]` with the latest tag from 
+[here](https://github.com/opensafely-actions/cox-ipw/tags), e.g., `v0.0.1`. 
+Note that no space is allowed between `cox-ipw:` and `[version]`.
 
 ```yaml
 my_cox_ipw:

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,8 @@ The action:
 
 ## Usage
 
-The arguments to the action are specified using the flags style (i.e., `--argname=argvalue`), the arguments are as follows.
+The arguments/options to the action are specified using the flags style (i.e., `--argname=argvalue`), 
+the arguments are as follows.
 
 ```{r, include=FALSE}
 # Taken from

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,8 +53,20 @@ where you should replace `[version]` with the latest tag from
 Note that no space is allowed between `cox-ipw:` and `[version]`.
 
 ```yaml
-my_cox_ipw:
-  run: cox-ipw:
+generate_study_population:
+  run: cohortextractor:latest generate_cohort --study-definition study_definition
+  outputs:
+    highly_sensitive:
+      cohort: output/input.csv
+
+cox_ipw:
+  run: cox-ipw:[version]
+  needs:
+  - generate_study_population
+  outputs:
+    moderately_sensitive:
+      arguments: output/args-results.csv
+      estimates: output/results.csv
 ```
 
 This action can be run specifying arguments as follows 

--- a/README.Rmd
+++ b/README.Rmd
@@ -76,11 +76,22 @@ This action can be run specifying arguments as follows
 (in YAML `>` indicates to treat the subsequent nested lines as a single line).
 
 ```yaml
-my_cox_ipw:
+generate_study_population:
+  run: cohortextractor:latest generate_cohort --study-definition study_definition
+  outputs:
+    highly_sensitive:
+      cohort: output/input.csv
+
+cox_ipw_2:
   run: >
-    cox-ipw: 
-      --df_input=other_input_file.csv
-      --df_output=other_output_file.csv
+    cox-ipw:[version]
+      --df_output=results_2.csv
+  needs:
+  - generate_study_population
+  outputs:
+    moderately_sensitive:
+      arguments: output/args-results_2.csv
+      estimates: output/results_2.csv
 ```
 
 ## Notes for developers

--- a/README.Rmd
+++ b/README.Rmd
@@ -69,6 +69,9 @@ cox_ipw:
       estimates: output/results.csv
 ```
 
+Note that the csv file of argument values is automatically named with `args-` prepended to the name of the output data csv file. 
+Hence, both the output data file and the file of argument values should be listed as `moderately_sensitive` outputs as shown above.
+
 This action can be run specifying arguments as follows 
 (in YAML `>` indicates to treat the subsequent nested lines as a single line).
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ The action:
 
 ## Usage
 
-The arguments to the action are specified using the flags style (i.e.,
-`--argname=argvalue`), the arguments are as follows.
+The arguments/options to the action are specified using the flags style
+(i.e., `--argname=argvalue`), the arguments are as follows.
 
-    Usage: cox-ipw: [options]
+    Usage: cox-ipw:[version] [options]
 
 
     Options:
-    --df_input=FILEPATH/FILENAME.CSV
-    Input dataset filename, including filepath [default input.csv]
+    --df_input=FILENAME.CSV
+    Input dataset csv filename (this is assumed to be within the output directory)
+    [default input.csv]
 
     --ipw=TRUE/FALSE
     Logical, indicating whether sampling and IPW are to be applied [default TRUE]
@@ -101,8 +102,9 @@ The arguments to the action are specified using the flags style (i.e.,
     Logical, if age should be included in the model as a spline with knots at 0.1,
     0.5, 0.9 [default TRUE]
 
-    --df_output=FILEPATH/FILENAME.CSV
-    Filename with filepath for output data [default results.csv]
+    --df_output=FILENAME.CSV
+    Output data csv filename (this is assumed to be within the output directory)
+    [default results.csv]
 
     --seed=INTEGER
     Random number generator seed passed to IPW sampling [default 137]
@@ -110,23 +112,55 @@ The arguments to the action are specified using the flags style (i.e.,
     -h, --help
     Show this help message and exit
 
-This action can be specified in the `project.yaml` with its default
-values as follows.
+This action can be specified in the `project.yaml` with its options at
+their default values as follows, where you should replace `[version]`
+with the latest tag from
+[here](https://github.com/opensafely-actions/cox-ipw/tags), e.g.,
+`v0.0.1`. Note that no space is allowed between `cox-ipw:` and
+`[version]`.
 
 ``` yaml
-my_cox_ipw:
-  run: cox-ipw:
+generate_study_population:
+  run: cohortextractor:latest generate_cohort --study-definition study_definition
+  outputs:
+    highly_sensitive:
+      cohort: output/input.csv
+
+cox_ipw:
+  run: cox-ipw:[version]
+  needs:
+  - generate_study_population
+  outputs:
+    moderately_sensitive:
+      arguments: output/args-results.csv
+      estimates: output/results.csv
 ```
+
+Note that the csv file of argument values is automatically named with
+`args-` prepended to the name of the output data csv file. Hence, both
+the output data file and the file of argument values should be listed as
+`moderately_sensitive` outputs as shown above.
 
 This action can be run specifying arguments as follows (in YAML `>`
 indicates to treat the subsequent nested lines as a single line).
 
 ``` yaml
-my_cox_ipw:
+generate_study_population:
+  run: cohortextractor:latest generate_cohort --study-definition study_definition
+  outputs:
+    highly_sensitive:
+      cohort: output/input.csv
+
+cox_ipw_2:
   run: >
-    cox-ipw: 
-      --df_input=other_input_file.csv
-      --df_output=other_output_file.csv
+    cox-ipw:[version]
+      --df_output=results_2.csv
+  needs:
+  - generate_study_population
+  outputs:
+    moderately_sensitive:
+      arguments: output/args-results_2.csv
+      estimates: output/results_2.csv
 ```
 
 ## Notes for developers

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -74,8 +74,8 @@ option_list <- list(
               help = "Logical, if age should be included in the model as a spline with knots at 0.1, 0.5, 0.9 [default %default]",
               metavar = "TRUE/FALSE"),
   make_option("--df_output", type = "character", default = "results.csv",
-              help = "Filename with filepath for output data [default %default]",
-              metavar = "filepath/filename.csv"),
+              help = "Output data csv filename (this is assumed to be within the output directory) [default %default]",
+              metavar = "filename.csv"),
   make_option("--seed", type = "integer", default = 137L,
               help = "Random number generator seed passed to IPW sampling [default %default]",
               metavar = "integer")

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -11,8 +11,8 @@
 library(optparse)
 option_list <- list(
   make_option("--df_input", type = "character", default = "input.csv",
-              help = "Input dataset filename, including filepath [default %default]",
-              metavar = "filepath/filename.csv"),
+              help = "Input dataset csv filename (this is assumed to be within the output directory) [default %default]",
+              metavar = "filename.csv"),
   make_option("--ipw", type = "logical", default = TRUE,
               help = "Logical, indicating whether sampling and IPW are to be applied [default %default]",
               metavar = "TRUE/FALSE"),

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -80,7 +80,7 @@ option_list <- list(
               help = "Random number generator seed passed to IPW sampling [default %default]",
               metavar = "integer")
 )
-opt_parser <- OptionParser(usage = "cox-ipw: [options]", option_list = option_list)
+opt_parser <- OptionParser(usage = "cox-ipw:[version] [options]", option_list = option_list)
 opt <- parse_args(opt_parser)
 
 # Record input arguments --------------------------------------------------------

--- a/project.yaml
+++ b/project.yaml
@@ -21,3 +21,15 @@ actions:
         moderately_sensitive:
           arguments: output/args-results.csv
           estimates: output/results.csv
+
+  # Test the action works in the system and with a flag
+  cox_ipw_2:
+    run: >
+      cox-ipw:v0.0.1
+        --df_output=results_2.csv
+    needs:
+    - generate_study_population
+    outputs:
+        moderately_sensitive:
+          arguments: output/args-results_2.csv
+          estimates: output/results_2.csv

--- a/project.yaml
+++ b/project.yaml
@@ -12,6 +12,8 @@ actions:
         cohort: output/input.csv
 
   cox_ipw:
+    # For user-facing documentation, call:
+    # cox-ipw:[version]
     run: r:latest analysis/cox-ipw.R
     needs:
     - generate_study_population


### PR DESCRIPTION
This 

* improves the documentation in the `README` 
* provides fuller YAML syntax for the examples in the `README`
* adds an action to `project.yaml` which uses the `cox-ipw` syntax
* tweaks `.gitattribues` to include Rmd in the Languages pane

(nb. the second job of `.github/workflows/main.yml` will automatically generate a new git tag if/when you merge this - so we don't need to make that ourselves)
