### PR TITLE
Fix the test_runner GHA so it just runs on PRs

### DIFF
--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -1,6 +1,6 @@
 name: Test that the project is runnable
 
-on: [push, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DOCKER_RO_TOKEN: ${{ secrets.DOCKER_RO_TOKEN }}

--- a/project.yaml
+++ b/project.yaml
@@ -23,13 +23,13 @@ actions:
           estimates: output/results.csv
 
   # Test the action works in the system and with a flag
-  cox_ipw_2:
-    run: >
-      cox-ipw:v0.0.1
-        --df_output=results_2.csv
-    needs:
-    - generate_study_population
-    outputs:
-        moderately_sensitive:
-          arguments: output/args-results_2.csv
-          estimates: output/results_2.csv
+  # cox_ipw_2:
+  #   run: >
+  #     cox-ipw:v0.0.1
+  #       --df_output=results_2.csv
+  #   needs:
+  #   - generate_study_population
+  #   outputs:
+  #       moderately_sensitive:
+  #         arguments: output/args-results_2.csv
+  #         estimates: output/results_2.csv


### PR DESCRIPTION
Fixes my mistake from earlier.

I feel it's nicer for the PR reviewer if the test runner is run on PRs.

I have kept the 2 yamls as separate files for simplicity (and also unsure if possible to add running on PRs to just one of the jobs in main.yml).

I also commented out the action which ran on the v0.0.1 as that doesn't need to be run every time - and people can still copy that code and uncomment it if they need to.