### PR TITLE
Add median person-time per episode to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# [v0.0.6](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.6)
+
+- Added median person-time per episode to output
+- Added CHANGELOG.md
+
+# [v0.0.5](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.5)
+
+- Added reporting of protected covariates that stop model running
+- Updated defaults
+- Updated how args are recorded
+- Added error capturing so jobs always complete
+- Increased population size so model runs on test data
+- Tidied formatting
+
+# [v0.0.4](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.4)
+
+- Updated test action
+
+# [v0.0.3](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.3)
+
+- Removed automatic cut points
+
+# [v0.0.2](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.2)
+
+- Improved documentation
+
+# [v0.0.1](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.1)

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -321,7 +321,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     print("Merge results with number of events and person time")
     
     results <- merge(results,
-                     episode_info[, c("time_period", "N_events", "person_time")],
+                     episode_info[, c("time_period", "N_events", "person_time_total",  "person_time_median")],
                      by.x = "term",
                      by.y = "time_period",
                      all.x = TRUE)
@@ -337,7 +337,8 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
                       covariate_removed = "",
                       covariate_collapsed = "",
                       N_events = episode_info[episode_info$time_period == "days_pre", ]$N_events,
-                      person_time = episode_info[episode_info$time_period == "days_pre",]$person_time,
+                      person_time_total = episode_info[episode_info$time_period == "days_pre",]$person_time_total,
+                      person_time_median = episode_info[episode_info$time_period == "days_pre",]$person_time_median,
                       stringsAsFactors = FALSE)
     
     results <- rbind(results, tmp)
@@ -356,7 +357,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     results <- results[order(results$model),
                        c("model", "exposure", "outcome", "term",
                          "estimate", "robust.conf.low", "robust.conf.high", "robust.se", "se",
-                         "N_total", "N_exposed", "N_events", "person_time", 
+                         "N_total", "N_exposed", "N_events", "person_time_total",  "person_time_median",
                          "surv_formula","input")]
     
   }


### PR DESCRIPTION
- Add median person-time per episode to output ([a0c6a27](https://github.com/opensafely-actions/cox-ipw/pull/16/commits/a0c6a27727dc2bcc0442a3057fae35623f7ec603))