### PR TITLE
Count outcomes per episode using status rather than date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.7](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.7)
+
+- Fixed outcomes per episode calculation
+
 # [v0.0.6](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.6)
 
 - Added median person-time per episode to output

--- a/analysis/fn-get_episode_info.R
+++ b/analysis/fn-get_episode_info.R
@@ -2,7 +2,7 @@ get_episode_info <- function(df, cut_points, episode_labels) {
 
   # Calculate number of events per episode -------------------------------------
 
-  events <- df[!is.na(df$outcome), c("patient_id","episode")]
+  events <- df[df$outcome_status==1, c("patient_id","episode")]
   
   events <- aggregate(episode ~ patient_id, data = events, FUN = max)
   


### PR DESCRIPTION
Count outcomes per episode using outcome status rather than outcome date variable