### PR TITLE
Remove covariate protect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.8](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.8)
+
+- Remove protected covariate feature due to lack of generalizability
+
 # [v0.0.7](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.7)
 
 - Fixed outcomes per episode calculation

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,7 @@ source_lines <- function(file, lines) {
 }
 # Note: in the following command the last line should be the line that
 # creates the opt_parser object using OptionParser(...)
-source_lines("analysis/cox-ipw.R", 1:80)
+source_lines("analysis/cox-ipw.R", 1:76)
 optparse::print_help(opt_parser)
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ The arguments/options to the action are specified using the flags style
     only [default
     cov_cat_ethnicity;cov_num_consulation_rate;cov_bin_healthcare_worker;cov_bin_carehome_status]
 
-    --covariate_protect=VARNAME_1;VARNAME_2;...
-    Semi-colon separated list of protected covariates - if checks indicate one of
-    these variables is to be removed from the regression model then an error is
-    returned [default cov_cat_ethnicity;cov_cat_region;cov_cat_sex;cov_num_age]
-
     --cox_start=VARNAME_1;VARNAME_2;...
     Semi-colon separated list of variable names used to define start of patient
     follow-up or single variable if already defined [default pat_index_date]


### PR DESCRIPTION
Remove covariate protection feature as this is not compatible with having a single model specification for multiple subgroups as some subgroups (e.g., sex) require protected covariates to be removed.