### PR TITLE
Make v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.0.10](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.10)
+
+- Add cox-ipw version number to output
+- Use Breslow for ties in Cox model
+- Add option to save analysis ready dataset
+
 # [v0.0.9](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.9)
 
 - Fix robust SEs so they are only applied when sampling is on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Use Breslow for ties in Cox model
 - Add option to save analysis ready dataset
 - Print survival::tmerge() inputs to log
+- Make outcome_time_median include time from previous episodes
 
 # [v0.0.9](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # [v0.0.10](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.10)
 
-- Add cox-ipw version number to output
-- Use Breslow for ties in Cox model
+- Add `cox-ipw` version number to output
+- Use Breslow method for ties in Cox model
 - Add option to save analysis ready dataset
-- Print survival::tmerge() inputs to log
-- Make outcome_time_median include time from previous episodes
+- Print `survival::tmerge()` inputs to log
+- Make `outcome_time_median` include time from previous episodes
 
 # [v0.0.9](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add cox-ipw version number to output
 - Use Breslow for ties in Cox model
 - Add option to save analysis ready dataset
+- Print survival::tmerge() inputs to log
 
 # [v0.0.9](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.9)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,7 @@ source_lines <- function(file, lines) {
 }
 # Note: in the following command the last line should be the line that
 # creates the opt_parser object using OptionParser(...)
-source_lines("analysis/cox-ipw.R", 1:76)
+source_lines("analysis/cox-ipw.R", 1:79)
 optparse::print_help(opt_parser)
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ action for the OpenSAFELY framework.
 
 The action:
 
--   Samples data and applies inverse probability weights
--   Performs survival data setup
--   Checks covariate variation
--   Fits the specified Cox model
+- Samples data and applies inverse probability weights
+- Performs survival data setup
+- Checks covariate variation
+- Fits the specified Cox model
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The arguments/options to the action are specified using the flags style
     --seed=INTEGER
     Random number generator seed passed to IPW sampling [default 137]
 
+    --save_analysis_ready=TRUE/FALSE
+    Logical, if analysis ready dataset should be saved [default FALSE]
+
     -h, --help
     Show this help message and exit
 

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -71,7 +71,10 @@ option_list <- list(
               metavar = "filename.csv"),
   make_option("--seed", type = "integer", default = 137L,
               help = "Random number generator seed passed to IPW sampling [default %default]",
-              metavar = "integer")
+              metavar = "integer"),
+  make_option("--save_analysis_ready", type = "logical", default = FALSE,
+              help = "Logical, if analysis ready dataset should be saved [default %default]",
+              metavar = "TRUE/FALSE")
 )
 opt_parser <- OptionParser(usage = "cox-ipw:[version] [options]", option_list = option_list)
 opt <- parse_args(opt_parser)
@@ -297,11 +300,19 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     
   }
   
-  # Perform Cox modelling ----------------------------------------------------
-  print("Perform Cox modelling")
+  # Save analysis ready dataset ------------------------------------------------
+  print("Save analysis ready dataset")
   
   data_surv[, c("study_start", "study_stop")] <- NULL
   
+  if (opt$save_analysis_ready == TRUE) {
+    readr::write_rds(data_surv, 
+                     file = paste0("output/analysis_ready-", gsub("\\...*","",opt$df_input),".rds"))
+  }
+  
+  # Perform Cox modelling ----------------------------------------------------
+  print("Perform Cox modelling")
+
   results <- fit_model(df = data_surv,
                        time_periods = episode_info[episode_info$time_period != "days_pre", ]$time_period,
                        covariates = covariate_other,

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -360,6 +360,8 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
 # Save output ------------------------------------------------------------------
 print("Save output")
 
+results$cox_ipw <- "v0.0.10"
+
 write.csv(results,
           file = paste0("output/", opt$df_output),
           row.names = FALSE)

--- a/analysis/fn-fit_model.R
+++ b/analysis/fn-fit_model.R
@@ -88,6 +88,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
       fit_cox_model_adj <- rms::cph(formula = as.formula(surv_formula_adj),
                                 data = df, 
                                 weight = df$cox_weights,
+                                method = "breslow",
                                 surv = TRUE,
                                 x = TRUE,
                                 y = TRUE)
@@ -96,6 +97,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
       
       fit_cox_model_adj <- rms::cph(formula = as.formula(surv_formula_adj),
                                 data = df, 
+                                method = "breslow",
                                 surv = TRUE,
                                 x = TRUE,
                                 y = TRUE)

--- a/analysis/fn-fit_model.R
+++ b/analysis/fn-fit_model.R
@@ -37,6 +37,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
     fit_cox_model <- rms::cph(formula = as.formula(surv_formula),
                               data = df, 
                               weight = df$cox_weights,
+                              method = "breslow",
                               surv = TRUE,
                               x = TRUE,
                               y = TRUE)
@@ -45,6 +46,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
     
     fit_cox_model <- rms::cph(formula = as.formula(surv_formula),
                               data = df, 
+                              method = "breslow",
                               surv = TRUE,
                               x = TRUE,
                               y = TRUE)

--- a/analysis/fn-get_episode_info.R
+++ b/analysis/fn-get_episode_info.R
@@ -43,6 +43,13 @@ get_episode_info <- function(df, cut_points, episode_labels) {
   
   episode_info <- merge(episode_info, tmp, by = "episode", all.x = TRUE)
   
+  # Add time from previous episodes to median person-time -----------------------
+  
+  episode_info$add <- as.numeric(gsub("days","",gsub("_.*","",episode_info$time_period)))
+  episode_info$add <- ifelse(is.na(episode_info$add),0,episode_info$add)
+  episode_info$outcome_time_median <- episode_info$outcome_time_median + episode_info$add
+  episode_info$add <- NULL
+  
   # Return episode_info table --------------------------------------------------
   
   return(episode_info)

--- a/analysis/fn-survival_data_setup.R
+++ b/analysis/fn-survival_data_setup.R
@@ -15,7 +15,12 @@ survival_data_setup <- function(df, cut_points, episode_labels) {
   
   ## Put into survival format
   d1 <- exposed[,!(colnames(exposed) %in% c("days_to_start", "days_to_exp", "days_to_end", "outcome_status"))]
+  print("Survival format, d1")
+  print(head(d1))
+  
   d2 <- exposed[,c("patient_id", "days_to_start", "days_to_exp", "days_to_end", "outcome_status")]
+  print("Survival format, d2")
+  print(head(d2))
   
   exposed <- survival::tmerge(data1=d1, 
                               data2=d2, 


### PR DESCRIPTION
- Add cox-ipw version number to output  - see [7400dc5](https://github.com/opensafely-actions/cox-ipw/pull/25/commits/7400dc5213a3ae842848704eb1d24d5e7c972c3b)
- Use Breslow for ties in Cox model - see [771b8cb](https://github.com/opensafely-actions/cox-ipw/pull/25/commits/771b8cbc5c9fca3ea0c71133086de19d17c2dcb8)
- Add option to save analysis ready dataset - see [4f424b9](https://github.com/opensafely-actions/cox-ipw/pull/25/commits/4f424b9227d7b2f83613d1c8689ebb3e889e3638)
- Print survival::tmerge() inputs to log - see [dc5b3d4](https://github.com/opensafely-actions/cox-ipw/pull/25/commits/dc5b3d4f1402feb038f8e71e31dfe427fb96417d)
- Make outcome_time_median include time from previous episodes - see [2aa8d1f](https://github.com/opensafely-actions/cox-ipw/pull/25/commits/2aa8d1f5386be8296185486a59dab3d89ad1a2e4)