### PR TITLE
Tidy naming in ipw sample script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.19](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.19)
+
+- Tidy naming in ipw sample script
+
 # [v0.0.18](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.18)
 
 - Add origin for data converted to date format

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -259,7 +259,6 @@ if (opt$ipw == TRUE) {
 
 print(summary(input))
 
-
 # Define episode labels --------------------------------------------------------
 print("Define episode labels")
 

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -453,7 +453,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
 # Save output ------------------------------------------------------------------
 print("Save output")
 
-results$cox_ipw <- "v0.0.18"
+results$cox_ipw <- "v0.0.19"
 
 write.csv(results,
           file = paste0("output/", opt$df_output),

--- a/analysis/fn-ipw_sample.R
+++ b/analysis/fn-ipw_sample.R
@@ -14,21 +14,28 @@ ipw_sample <- function(df, controls_per_case, seed = 137, sample_exposed) {
   print(paste0("Cases: ",nrow(cases)))
   print(summary(cases))
   
-  print(paste0("Controls:",nrow(controls)))
+  print(paste0("Controls: ",nrow(controls)))
   print(summary(controls))
   
   # Sample controls if more than enough, otherwise retain all controls ---------
   
-  if (nrow(cases)*controls_per_case<nrow(controls)) {
     
     if (sample_exposed==TRUE) {
       
-      print("Sample controls, including exposed control individuals")
-      controls <- controls[sample(1:nrow(controls), nrow(cases)*controls_per_case, replace = FALSE),]
-      controls$cox_weight <- (nrow(df)-nrow(cases))/nrow(controls)
-      print(paste0(nrow(controls), " controls sampled"))
-      print(summary(controls$cox_weight))
-      
+      if (nrow(cases)*controls_per_case<nrow(controls)) {
+        
+          print("Sample controls, including exposed control individuals")
+          controls <- controls[sample(1:nrow(controls), nrow(cases)*controls_per_case, replace = FALSE),]
+          controls$cox_weight <- (nrow(df)-nrow(cases))/nrow(controls)
+          print(paste0(nrow(controls), " controls sampled with Cox weight of ",controls$cox_weight[1]))
+        
+      } else {
+        
+        print("Retain all controls")
+        controls$cox_weight <- 1
+        
+      }
+     
     }
     
     if (sample_exposed==FALSE) {
@@ -36,32 +43,38 @@ ipw_sample <- function(df, controls_per_case, seed = 137, sample_exposed) {
       print("Separate exposed controls so they are not sampled")
       controls_exposed <- controls[!is.na(controls$exposure),]
       controls_exposed$cox_weight <- 1
+      print(paste0(nrow(controls_exposed), " exposed controls"))
       
-      print(paste0("Exposed controls (N=",nrow(controls_exposed), "):"))
+      print("Exposed controls:")
       print(summary(controls_exposed))
-
+      
       print("Sample unexposed controls")
       controls_unexposed <- controls[is.na(controls$exposure),]
-      controls_unexposed <- controls_unexposed[sample(1:nrow(controls_unexposed), nrow(cases)*controls_per_case, replace = FALSE),]
-      controls_unexposed$cox_weight <- (nrow(df)-nrow(cases)-nrow(controls_exposed))/nrow(controls_unexposed)
       
-      print(paste0("Unexposed controls (N=",nrow(controls_unexposed), "):"))
-      print(summary(controls_unexposed))
+      if (nrow(cases)*controls_per_case<nrow(controls_unexposed)) {
       
-      print("Add exposed control individuals back to control dataset")
-      controls <- NULL
-      controls <- rbind(controls_unexposed,controls_exposed)
-      print(paste0("Controls (N=",nrow(controls), "):"))
-      print(summary(controls))
+        controls_unexposed <- controls_unexposed[sample(1:nrow(controls_unexposed), nrow(cases)*controls_per_case, replace = FALSE),]
+        controls_unexposed$cox_weight <- (nrow(df)-nrow(cases)-nrow(controls_exposed))/nrow(controls_unexposed)
+        print(paste0(nrow(controls_unexposed), " unexposed controls sampled with Cox weight of ",controls_unexposed$cox_weight[1]))
+        
+        print("Unexposed controls:")
+        print(summary(controls_unexposed))
+        
+        print("Add exposed control individuals back to control dataset")
+        controls <- NULL
+        controls <- rbind(controls_unexposed,controls_exposed)
+        print(paste0("Controls (N=",nrow(controls), "):"))
+        print(summary(controls))
       
-    }
+      } else {
+        
+        print("Insufficient controls so retain all controls")
+        rm(controls_exposed, controls_unexposed)
+        controls$cox_weight <- 1
+        
+      }
     
-  } else {
-    
-    print("Retain all controls")
-    controls$cox_weight <- 1
-    
-  }
+    } 
   
   # Specify cox weight for cases -----------------------------------------------
   print("Specify cox weight for cases")

--- a/analysis/fn-ipw_sample.R
+++ b/analysis/fn-ipw_sample.R
@@ -34,24 +34,24 @@ ipw_sample <- function(df, controls_per_case, seed = 137, sample_exposed) {
     if (sample_exposed==FALSE) {
       
       print("Separate exposed controls so they are not sampled")
-      exposed <- controls[!is.na(controls$exposure),]
-      controls <- controls[is.na(controls$exposure),]
-      exposed$cox_weight <- 1
+      controls_exposed <- controls[!is.na(controls$exposure),]
+      controls_exposed$cox_weight <- 1
       
-      print("Exposed controls:")
-      print(summary(exposed))
+      print(paste0("Exposed controls (N=",nrow(controls_exposed), "):"))
+      print(summary(controls_exposed))
+
+      print("Sample unexposed controls")
+      controls_unexposed <- controls[is.na(controls$exposure),]
+      controls_unexposed <- controls_unexposed[sample(1:nrow(controls_unexposed), nrow(cases)*controls_per_case, replace = FALSE),]
+      controls_unexposed$cox_weight <- (nrow(df)-nrow(cases)-nrow(controls_exposed))/nrow(controls_unexposed)
       
-      print("Unexposed controls:")
-      print(summary(controls))
-      
-      print("Sample controls, not including exposed control individuals")
-      controls <- controls[sample(1:nrow(controls), nrow(cases)*controls_per_case, replace = FALSE),]
-      controls$cox_weight <- (nrow(df)-nrow(exposed)-nrow(cases))/nrow(controls)
-      print(paste0(nrow(controls), " controls sampled"))
-      print(summary(controls$cox_weight))
+      print(paste0("Unexposed controls (N=",nrow(controls_unexposed), "):"))
+      print(summary(controls_unexposed))
       
       print("Add exposed control individuals back to control dataset")
-      controls <- rbind(controls,exposed)
+      controls <- NULL
+      controls <- rbind(controls_unexposed,controls_exposed)
+      print(paste0("Controls (N=",nrow(controls), "):"))
       print(summary(controls))
       
     }
@@ -71,10 +71,10 @@ ipw_sample <- function(df, controls_per_case, seed = 137, sample_exposed) {
   # Recombine cases and controls -----------------------------------------------
   print("Recombine cases and controls")
   
-  df <- rbind(cases,controls)
+  return_df <- rbind(cases,controls)
   
   # Return dataset -------------------------------------------------------------
   
-  return(df) 
+  return(return_df) 
   
 }


### PR DESCRIPTION
I have tidied the naming in the ipw sample script as we have identified an error that occurs when the sample_exposed flag is set to false that we are trying to debug.