### PR TITLE
Small R code improvements from VSCode linting warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.21](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.21)
+
+- Various improvements to the code to fix linting warnings
+
 # [v0.0.20](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.20)
 
 - Fix weighting bug for models

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -453,7 +453,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
 # Save output ------------------------------------------------------------------
 print("Save output")
 
-results$cox_ipw <- "v0.0.20"
+results$cox_ipw <- "v0.0.21"
 
 write.csv(results,
           file = paste0("output/", opt$df_output),

--- a/analysis/fn-check_covariates.R
+++ b/analysis/fn-check_covariates.R
@@ -1,5 +1,7 @@
 check_covariates <- function(df, covariate_threshold, strata) {
 
+  library(magrittr)
+
   # Identify non-numeric covariates to remove ----------------------------------
   print("Identify non-numeric covariates to remove")
   

--- a/analysis/fn-check_covariates.R
+++ b/analysis/fn-check_covariates.R
@@ -9,7 +9,7 @@ check_covariates <- function(df, covariate_threshold, strata) {
     
     # Consider non-numeric covariates ------------------------------------------
     
-    if (grepl("cov_bin_",i) | grepl("cov_cat_",i)) {
+    if (grepl("cov_bin_",i) || grepl("cov_cat_",i)) {
       
       print(paste0("Covariate: ",i))
       

--- a/analysis/fn-fit_model.R
+++ b/analysis/fn-fit_model.R
@@ -81,7 +81,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
   
   # If covariates are specified, run an additional model including them --------
   
-  covariates <- setdiff(covariate_other, covariate_removed)
+  covariates <- setdiff(covariates, covariate_removed)
   
   if (!is.null(covariates) && length(covariates)>0) {
     

--- a/analysis/fn-fit_model.R
+++ b/analysis/fn-fit_model.R
@@ -15,7 +15,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
     
     print("Add age covariate")
     
-    if (age_spline=="TRUE") {
+    if (age_spline==TRUE) {
       
       print("Specify knot placement for age spline")
       

--- a/analysis/fn-fit_model.R
+++ b/analysis/fn-fit_model.R
@@ -83,7 +83,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
   
   covariates <- setdiff(covariate_other, covariate_removed)
   
-  if (!is.null(covariates) & length(covariates)>0) {
+  if (!is.null(covariates) && length(covariates)>0) {
     
     # Add covariates to model formula ------------------------------------------
     print("Add covariates to model formula")

--- a/analysis/fn-get_episode_info.R
+++ b/analysis/fn-get_episode_info.R
@@ -1,5 +1,7 @@
 get_episode_info <- function(df, cut_points, episode_labels, ipw) {
 
+  library(magrittr)
+
   # Calculate number of events per episode -------------------------------------
   print("Calculate number of events per episode")
   

--- a/analysis/fn-ipw_sample.R
+++ b/analysis/fn-ipw_sample.R
@@ -25,7 +25,7 @@ ipw_sample <- function(df, controls_per_case, seed = 137, sample_exposed) {
       if (nrow(cases)*controls_per_case<nrow(controls)) {
         
           print("Sample controls, including exposed control individuals")
-          controls <- controls[sample(1:nrow(controls), nrow(cases)*controls_per_case, replace = FALSE),]
+          controls <- controls[sample(seq_len(nrow(controls)), nrow(cases)*controls_per_case, replace = FALSE),]
           controls$cox_weight <- (nrow(df)-nrow(cases))/nrow(controls)
           print(paste0(nrow(controls), " controls sampled with Cox weight of ",controls$cox_weight[1]))
         
@@ -53,7 +53,7 @@ ipw_sample <- function(df, controls_per_case, seed = 137, sample_exposed) {
       
       if (nrow(cases)*controls_per_case<nrow(controls_unexposed)) {
       
-        controls_unexposed <- controls_unexposed[sample(1:nrow(controls_unexposed), nrow(cases)*controls_per_case, replace = FALSE),]
+        controls_unexposed <- controls_unexposed[sample(seq_len(nrow(controls_unexposed)), nrow(cases)*controls_per_case, replace = FALSE),]
         controls_unexposed$cox_weight <- (nrow(df)-nrow(cases)-nrow(controls_exposed))/nrow(controls_unexposed)
         print(paste0(nrow(controls_unexposed), " unexposed controls sampled with Cox weight of ",controls_unexposed$cox_weight[1]))
         

--- a/analysis/fn-survival_data_setup.R
+++ b/analysis/fn-survival_data_setup.R
@@ -54,7 +54,7 @@ survival_data_setup <- function(df, cut_points, episode_labels) {
   
   print(summary(exposed_post))
   
-  exposed_post <- survSplit(Surv(tstop, outcome_status) ~ ., 
+  exposed_post <- survival::survSplit(Surv(tstop, outcome_status) ~ ., 
                             exposed_post,
                             cut=cut_points,
                             episode="episode")


### PR DESCRIPTION
Hi @venexia 

(out of guilt about the previous typo) I went through all the VSCode R linting output for the .R files. 

It started with 0 (linting) errors, 27 (linting) warnings, and alot of (linting) infos (see this in bottom lefthand corner of VSCode window).

<img width="325" alt="screen-1-3" src="https://user-images.githubusercontent.com/3777473/212989704-93a74c48-2906-4218-9b00-271c3addb907.png">

After these commits there are 0 (linting) errors, 15 (linting) warnings, and alot of (linting) infos (I think all remaining linting warnings are spurious).

<img width="383" alt="screen-1-2" src="https://user-images.githubusercontent.com/3777473/212989854-79d762e9-14e9-418f-bb4e-c54402a96d1e.png">

I think none of these changes actually affect output of previously run jobs, but the new code is a bit more robust at least.

The most useful find was that in `fn-fit_model.R` on line 84 `covariate_other` was being used - but that was input into the `covariates` argument in that function - there was no error because `covariate_other` was defined in the global environment, so the previous code picked it up anyway, but safer to use the argument you specified I guess.
