### PR TITLE
update cox fup end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.25](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.25)
+
+- Update follow-up end criteria to include outcome
+
 # [v0.0.24](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.24)
 
 - Save the anaylysis ready dataset in csv.gz format instead of rds

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -219,7 +219,6 @@ input$fup_start <- do.call(pmax,
 input$fup_stop <- do.call(pmin,
                           c(input[, c("study_stop", cox_stop, "outcome")], list(na.rm = TRUE)))
 
-
 input <- input[input$fup_stop >= input$fup_start, ]
 
 print(summary(input))

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -456,7 +456,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     
     results$strata_warning <- strata_warning
     
-    results$cox_ipw <- "v0.0.24"
+    results$cox_ipw <- "v0.0.25"
     
     results <- results[order(results$model),
                        c("model", "exposure", "outcome", "term",

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -217,7 +217,8 @@ input$fup_start <- do.call(pmax,
                            c(input[, c("study_start", cox_start)], list(na.rm = TRUE)))
 
 input$fup_stop <- do.call(pmin,
-                          c(input[, c("study_stop", cox_stop)], list(na.rm = TRUE)))
+                          c(input[, c("study_stop", cox_stop, "outcome")], list(na.rm = TRUE)))
+
 
 input <- input[input$fup_stop >= input$fup_start, ]
 


### PR DESCRIPTION
Update how cox follow-up end date is defined.

The output from the cox-ipw was not matching the table 2 output for person days and event counts. I have updated and these now match using dummy data. I would potentially be tempted to add an extra script to double check that the output from table 2 matches that from the cox-ipw.

In the input arguments cox_stop = end_date_outcome which looks to be defined used the study end date (defined in prelim.R) so I think the changed line could be further simplified to:

input$fup_stop <- do.call(pmin,
                          c(input[, c(cox_stop, "outcome")], list(na.rm = TRUE)))

which is how it is defined in table 2 in mental health [here](https://github.com/opensafely/post-covid-mentalhealth/blob/97250e6060cc7e254a27779a190afbb59ced662d/analysis/table2.R#L77).

However I didn't want to remove "study_stop" just in case you knew anything different/thought it might still be needed?

