### PR TITLE
Make v0.0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [v0.0.30](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.30)
 
-- Add observation warning that returns a mesage if the number of observations provided to the model differs from the number of observations used by the model.
+- Add an observation warning that returns a message if the number of observations provided to the model differs from the number of observations used by the model.
 
 # [v0.0.29](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.30](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.30)
+
+- Add observation warning that returns a mesage if the number of observations provided to the model differs from the number of observations used by the model.
+
 # [v0.0.29](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.29)
 
 - The r image has been reverted to use the old version of the **readr** package. Hence, the `path` argument is now used again in the calls to `readr::write_csv()`.

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -429,6 +429,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
                       surv_formula = c(results[results$model=="mdl_age_sex",]$surv_formula[1], results[results$model=="mdl_max_adj",]$surv_formula[1]),
                       covariate_removed = "",
                       covariate_collapsed = "",
+                      obs_warning = "",
                       N_events = episode_info[episode_info$time_period == "days_pre", ]$N_events,
                       person_time_total = episode_info[episode_info$time_period == "days_pre",]$person_time_total,
                       outcome_time_median = episode_info[episode_info$time_period == "days_pre",]$outcome_time_median,
@@ -462,7 +463,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
                          "lnhr","se_lnhr", "hr","conf_low", "conf_high", 
                          "N_total", "N_exposed", "N_events", 
                          "person_time_total", "outcome_time_median",
-                         "covariate_collapsed","strata_warning",
+                         "covariate_collapsed","strata_warning","obs_warning",
                          "surv_formula","input","cox_ipw")]
   } else {
     

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -456,7 +456,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     
     results$strata_warning <- strata_warning
     
-    results$cox_ipw <- "v0.0.29"
+    results$cox_ipw <- "v0.0.30"
     
     results <- results[order(results$model),
                        c("model", "exposure", "outcome", "term",

--- a/analysis/fn-fit_model.R
+++ b/analysis/fn-fit_model.R
@@ -44,6 +44,8 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
 
   if (ipw==TRUE) {
     
+    N_obs_in <- nrow(df)
+    
     fit_cox_model <- rms::cph(formula = as.formula(surv_formula),
                               data = df, 
                               weight = df$cox_weight,
@@ -52,7 +54,11 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
                               x = TRUE,
                               y = TRUE)
     
+    N_obs_out <- sum(fit_cox_model$n)
+    
   } else {
+    
+    N_obs_in <- nrow(df)
     
     fit_cox_model <- rms::cph(formula = as.formula(surv_formula),
                               data = df, 
@@ -60,6 +66,8 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
                               surv = TRUE,
                               x = TRUE,
                               y = TRUE)
+    
+    N_obs_out <- sum(fit_cox_model$n)
     
   }
   
@@ -75,6 +83,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
                         surv_formula = surv_formula,
                         covariate_removed = "", 
                         covariate_collapsed = "",
+                        obs_warning = ifelse(N_obs_in==N_obs_out,"",paste0(N_obs_in," observations provided. ",N_obs_out," observations used.")),
                         stringsAsFactors = FALSE)
   
   row.names(results) <- NULL
@@ -102,6 +111,8 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
 
     if (ipw==TRUE) {
       
+      N_obs_in <- nrow(df)
+      
       fit_cox_model_adj <- rms::cph(formula = as.formula(surv_formula_adj),
                                     data = df, 
                                     weight = df$cox_weight,
@@ -110,7 +121,11 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
                                     x = TRUE,
                                     y = TRUE)
       
+      N_obs_out <- sum(fit_cox_model$n)
+      
     } else {
+      
+      N_obs_in <- nrow(df)
       
       fit_cox_model_adj <- rms::cph(formula = as.formula(surv_formula_adj),
                                     data = df, 
@@ -119,12 +134,15 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
                                     x = TRUE,
                                     y = TRUE)
       
+      N_obs_out <- sum(fit_cox_model$n)
+      
     }
     
     print(fit_cox_model_adj)
     
     # Format results ---------------------------------------------------------------
     print("Format results")
+    
     
     results_adj <- data.frame(term = names(fit_cox_model_adj$coefficients),
                               lnhr = fit_cox_model_adj$coefficients,
@@ -133,6 +151,7 @@ fit_model <- function(df, time_periods, covariates, strata, age_spline, covariat
                               surv_formula = surv_formula_adj,
                               covariate_removed = paste0(covariate_removed, collapse = ";"),
                               covariate_collapsed = paste0(covariate_collapsed, collapse = ";"),
+                              obs_warning = ifelse(N_obs_in==N_obs_out,"",paste0(N_obs_in," observations provided. ",N_obs_out," observations used.")),
                               stringsAsFactors = FALSE)
     
     row.names(results_adj) <- NULL


### PR DESCRIPTION
Add an observation warning that returns a message if the number of observations provided to the model differs from the number of observations used by the model. Note: to test this, you will need dummy data that has some missing values in a covariate.