### PR TITLE
Make v0.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [v0.0.31](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.31)
 
-- The `readr::write_csv()` calls are now more robust to the version of the readr package installed in the r image, i.e., if the version of readr is less that 1.4.0 then the `path` argument is used, otherwise the `file` argument is used. [Tidyverse blogpost about readr 1.4.0](https://www.tidyverse.org/blog/2020/10/readr-1-4-0/#argument-name-consistency).
+- Save analysis ready now uses `foreign::write.dta` so that output can be read directly into Stata
 
 # [v0.0.30](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.31](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.31)
+
+- The `readr::write_csv()` calls are now more robust to the version of the readr package installed in the r image, i.e., if the version of readr is less that 1.4.0 then the `path` argument is used, otherwise the `file` argument is used. [Tidyverse blogpost about readr 1.4.0](https://www.tidyverse.org/blog/2020/10/readr-1-4-0/#argument-name-consistency).
+
 # [v0.0.30](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.30)
 
 - Add an observation warning that returns a message if the number of observations provided to the model differs from the number of observations used by the model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [v0.0.31](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.31)
 
-- Save analysis ready now uses `foreign::write.dta` so that output can be read directly into Stata
+- Save analysis ready now uses `foreign::write.dta()` so that output can be read directly into Stata.
 
 # [v0.0.30](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.30)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -65,7 +65,7 @@ cox_ipw:
   - generate_study_population
   outputs:
     highly_sensitive:
-      analysis_ready: output/ready-*.csv.gz
+      analysis_ready: output/ready-*.dta
     moderately_sensitive:
       arguments: output/args-results.csv
       estimates: output/results.csv
@@ -92,7 +92,7 @@ cox_ipw_2:
   - generate_study_population
   outputs:
     highly_sensitive:
-      analysis_ready: output/ready-*.csv.gz
+      analysis_ready: output/ready-*.dta
     moderately_sensitive:
       arguments: output/args-results_2.csv
       estimates: output/results_2.csv

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The arguments/options to the action are specified using the flags style
     Random number generator seed passed to IPW sampling [default 137]
 
     --save_analysis_ready=TRUE/FALSE
-    Logical, if analysis ready dataset should be saved [default FALSE]
+    Logical, if analysis ready dataset for Stata should be saved [default FALSE]
 
     --run_analysis=TRUE/FALSE
     Logical, if analysis should be run [default TRUE]
@@ -133,7 +133,7 @@ cox_ipw:
   - generate_study_population
   outputs:
     highly_sensitive:
-      analysis_ready: output/ready-*.csv.gz
+      analysis_ready: output/ready-*.dta
     moderately_sensitive:
       arguments: output/args-results.csv
       estimates: output/results.csv
@@ -162,7 +162,7 @@ cox_ipw_2:
   - generate_study_population
   outputs:
     highly_sensitive:
-      analysis_ready: output/ready-*.csv.gz
+      analysis_ready: output/ready-*.dta
     moderately_sensitive:
       arguments: output/args-results_2.csv
       estimates: output/results_2.csv

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -76,7 +76,7 @@ option_list <- list(
               help = "Random number generator seed passed to IPW sampling [default %default]",
               metavar = "integer"),
   make_option("--save_analysis_ready", type = "logical", default = FALSE,
-              help = "Logical, if analysis ready dataset should be saved [default %default]",
+              help = "Logical, if analysis ready dataset for Stata should be saved [default %default]",
               metavar = "TRUE/FALSE"),
   make_option("--run_analysis", type = "logical", default = TRUE,
               help = "Logical, if analysis should be run [default %default]",
@@ -386,22 +386,12 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
   data_surv[, c("study_start", "study_stop")] <- NULL
   
   if (opt$save_analysis_ready == TRUE) {
-    if (packageVersion('readr') < '1.4.0') {
-      readr::write_csv(data_surv, 
-                       path = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
-    } else {
-      readr::write_csv(data_surv, 
-                       file = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
-    }
+    foreign::write.dta(data_surv, 
+                       paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".dta"))
   } else {
     analysis_ready_empty <- data.frame()
-    if (packageVersion('readr') < '1.4.0') {
-      readr::write_csv(analysis_ready_empty, 
-                       path = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
-    } else {
-            readr::write_csv(analysis_ready_empty, 
-                       file = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
-    }
+    foreign::write.dta(analysis_ready_empty, 
+                       paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".dta"))
   }
 
   if (opt$run_analysis == TRUE)  {

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -466,7 +466,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     
     results$strata_warning <- strata_warning
     
-    results$cox_ipw <- "v0.0.30"
+    results$cox_ipw <- "v0.0.31"
     
     results <- results[order(results$model),
                        c("model", "exposure", "outcome", "term",

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -386,12 +386,22 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
   data_surv[, c("study_start", "study_stop")] <- NULL
   
   if (opt$save_analysis_ready == TRUE) {
-    readr::write_csv(data_surv, 
-                     path = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
+    if (packageVersion('readr') < '1.4.0') {
+      readr::write_csv(data_surv, 
+                       path = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
+    } else {
+      readr::write_csv(data_surv, 
+                       file = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
+    }
   } else {
     analysis_ready_empty <- data.frame()
-    readr::write_csv(analysis_ready_empty, 
-                     path = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
+    if (packageVersion('readr') < '1.4.0') {
+      readr::write_csv(analysis_ready_empty, 
+                       path = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
+    } else {
+            readr::write_csv(analysis_ready_empty, 
+                       file = paste0("output/ready-", gsub("\\...*","",gsub("model_input-","",opt$df_input)),".csv.gz"))
+    }
   }
 
   if (opt$run_analysis == TRUE)  {


### PR DESCRIPTION
We have been experiencing issues with the analysis-ready dataset downstream and unzipping it in Stata. To remove this step, I have amended cox-ipw to save the analysis-ready dataset using `foreign::write.dta()` (sorry @remlapmot, I know this version was meant to be your nice fix to `readr::write_csv()`).

P.S. I have mixed feelings about this because of generalizability but I can't think of another solution to the issues we are having at present!