### PR TITLE
Fix potential race condition in tagging GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: tag-new-version-group
+  cancel-in-progress: false
+
 jobs:
   test-integration:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.33](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.33)
+
+- Fix potential race condition in tagging GitHub Actions workflow.
+
 # [v0.0.32](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.32)
 
 - Bump the [mathieudutour/github-tag-action](https://github.com/mathieudutour/github-tag-action) GitHub Action to version 6.2.

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -469,7 +469,7 @@ if (sum(episode_info[episode_info$time_period != "days_pre", ]$N_events) < total
     
     results$strata_warning <- strata_warning
     
-    results$cox_ipw <- "v0.0.32"
+    results$cox_ipw <- "v0.0.33"
     
     results <- results[order(results$model),
                        c("model", "exposure", "outcome", "term",


### PR DESCRIPTION
As per Iain's issue, this adds a concurrency group to ensure a race condition can't occur in the tagging workflow.

Closes #61 