### PR TITLE
Minor update to GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: opensafely-core/research-action@v2
 
   tag-new-version:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Tag new version
         uses: mathieudutour/github-tag-action@v6.2
         with:

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Test the project can run, using dummy data
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Test that the project is runnable
       uses: opensafely-core/research-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.38](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.38)
+
+- Minor updates to GitHub Actions workflows.
+
 # [v0.0.37](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.37)
 
 - Fix typo in README.


### PR DESCRIPTION
We may as well bump this to current version <https://github.com/actions/checkout> (which you can verify from the releases pane on that repo).