### PR TITLE
Tiny update to GitHub Actions workflows - bump actions/checkout to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: opensafely-core/research-action@v2
 
   tag-new-version:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Tag new version
         uses: mathieudutour/github-tag-action@v6.2
         with:

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Test the project can run, using dummy data
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Test that the project is runnable
       uses: opensafely-core/research-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.40](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.40)
+
+- Minor updates to GitHub Actions workflows.
+
 # [v0.0.39](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.39)
 
 - Allow option `--covariate_other` to be specified as a filename of a text file of semi-colon separated variable names.

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -679,7 +679,7 @@ if (
 
     results$strata_warning <- strata_warning
 
-    results$cox_ipw <- "v0.0.39"
+    results$cox_ipw <- "v0.0.40"
 
     results <- results[
       order(results$model),


### PR DESCRIPTION
GitHub have issued a v6 of https://github.com/actions/checkout annoyingly soon after the v5 was released. This simply bumps the workflows to use v6.