### PR TITLE
fix(covariate name): 'cov_num_consulation_rate' -> 'cov_num_consultation_rate'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [v0.0.41](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.41)
+
+- Fix typo `cov_num_consulation_rate` to `cov_num_consultation_rate`
+- Bump _project.yaml_ pipeline version to '5.0' (see <https://docs.opensafely.org/actions-pipelines/> for latest version)
+
 # [v0.0.40](https://github.com/opensafely-actions/cox-ipw/releases/tag/v0.0.40)
 
 - Minor updates to GitHub Actions workflows.

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -26,7 +26,7 @@ R -e "rmarkdown::render('README.Rmd')"
 
 ## Environment
 
-This is an R resuable action, run within the R container created from the [https://github.com/opensafely-core/r-docker](r-docker repository). The key points about the R container are as follows.
+This is an R reusable action, run within the R container created from the [https://github.com/opensafely-core/r-docker](r-docker repository). The key points about the R container are as follows.
 
 * Currently the `r:v2` image provides **R 4.4.2**.
 * The container provides the packages, with their respective version numbers, listed in [v2/packages.md](https://github.com/opensafely-core/r-docker/blob/main/v2/packages.md).

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -28,7 +28,7 @@ R -e "rmarkdown::render('README.Rmd')"
 
 This is an R reusable action, run within the R container created from the [https://github.com/opensafely-core/r-docker](r-docker repository). The key points about the R container are as follows.
 
-* Currently the `r:v2` image provides **R 4.4.2**.
+* Currently the `r:v2` image provides **R 4.4.3**.
 * The container provides the packages, with their respective version numbers, listed in [v2/packages.md](https://github.com/opensafely-core/r-docker/blob/main/v2/packages.md).
 
 For more information about reusable actions see [here](https://docs.opensafely.org/actions-reusable/).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ as follows:
     regression model; specify argument as NULL to run age, age squared, sex
     adjusted model only. Note that if you are including only a single covariate
     please include the semi-colon after it [default
-    cov_cat_ethnicity;cov_num_consulation_rate;cov_bin_healthcare_worker;cov_bin_carehome_status]
+    cov_cat_ethnicity;cov_num_consultation_rate;cov_bin_healthcare_worker;cov_bin_carehome_status]
     
     --cox_start=VARNAME_1;VARNAME_2;...
     Semi-colon separated list of variable names used to define start of patient

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -69,7 +69,7 @@ option_list <- list(
   make_option(
     "--covariate_other",
     type = "character",
-    default = "cov_cat_ethnicity;cov_num_consulation_rate;cov_bin_healthcare_worker;cov_bin_carehome_status",
+    default = "cov_cat_ethnicity;cov_num_consultation_rate;cov_bin_healthcare_worker;cov_bin_carehome_status",
     help = "Semi-colon separated list of other covariates or filename of text file containing semi-colon separated list of other covariates to be included in the regression model; specify argument as NULL to run age, age squared, sex adjusted model only. Note that if you are including only a single covariate please include the semi-colon after it [default %default]",
     metavar = "varname_1;varname_2;... or covariate-other.txt"
   ),

--- a/analysis/cox-ipw.R
+++ b/analysis/cox-ipw.R
@@ -679,7 +679,7 @@ if (
 
     results$strata_warning <- strata_warning
 
-    results$cox_ipw <- "v0.0.40"
+    results$cox_ipw <- "v0.0.41"
 
     results <- results[
       order(results$model),

--- a/dummy_tables/covariate-other.txt
+++ b/dummy_tables/covariate-other.txt
@@ -1,1 +1,1 @@
-cov_cat_ethnicity;cov_num_consulation_rate
+cov_cat_ethnicity;cov_num_consultation_rate

--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,4 @@
-version: '4.0'
+version: '5.0'
 
 actions:
 


### PR DESCRIPTION
## Summary

The default covariate name was misspelled as \`cov_num_consulation_rate\` (missing the first 't' in 'consultation'). Fixed atomically in three places so the action default, the dummy table fixture, and the README stay in sync:

- \`dummy_tables/covariate-other.txt\` (column header)
- \`analysis/cox-ipw.R\` (line 72 default)
- \`README.md\` (line 66 usage example)

Closes #74

## Testing

Name change only — no R logic modified. Note for consumers: if a downstream study already relies on the misspelled default, they'll need to pass the correct name explicitly when pulling the new version (or the author can gate this behind a deprecation alias if preferred — happy to iterate).